### PR TITLE
Rewrote authentication and began adding token checking to GraphQL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3183,6 +3183,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
       "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3481,6 +3482,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -3488,7 +3490,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -3529,12 +3532,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -3661,6 +3666,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -4188,6 +4194,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4393,6 +4400,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4871,7 +4879,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4958,12 +4967,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5080,7 +5091,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "3.0.0",
@@ -5706,6 +5718,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -5856,12 +5869,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -5964,6 +5979,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -6373,7 +6389,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6407,7 +6424,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -7101,7 +7119,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
@@ -7169,12 +7188,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7185,7 +7206,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.1.2",
@@ -7224,6 +7246,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7323,7 +7346,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -8234,7 +8258,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -8512,7 +8537,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -8630,7 +8656,8 @@
     "psl": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.7",
@@ -8651,7 +8678,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -8866,6 +8894,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -8893,6 +8922,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -8902,12 +8932,14 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -9535,6 +9567,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -9905,6 +9938,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -9912,7 +9946,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -10059,6 +10094,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -10133,6 +10169,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -10269,11 +10306,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3665,6 +3665,23 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bent": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bent/-/bent-7.3.1.tgz",
+      "integrity": "sha512-4nv/p7GaItr5FJ/CPiP0t3LZ1gETMaV+zXJU0X9tHiOuAPYZ8NA8ohIyugBMBV7q64X2OiDvBaqoQSUM2LuLjA==",
+      "requires": {
+        "bytesish": "^0.4.1",
+        "caseless": "~0.12.0",
+        "is-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -3815,6 +3832,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "bytesish": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.1.tgz",
+      "integrity": "sha512-j3l5QmnAbpOfcN/Z2Jcv4poQYfefs8rDdcbc6iEKm+OolvUXAE2APodpWj+DOzqX6Bl5Ys1cQkcIV2/doGvQxg=="
     },
     "cache-base": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,8 @@
     "graphql-compose": "^7.15.0",
     "graphql-compose-mongoose": "^7.3.8",
     "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.15",
     "mongodb": "^3.5.5",
     "mongoose": "^5.9.5",
-    "request": "^2.88.2",
-    "ws": "^7.3.0",
     "xml2js": "^0.4.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "apollo-server": "^2.11.0",
     "apollo-server-express": "^2.11.0",
+    "bent": "^7.3.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -3,9 +3,11 @@ import 'dotenv/config';
 const CLIENT_TOKEN_SECRET = process.env.CLIENT_TOKEN_SECRET;
 const MONGODB_CONNECTION_URL = process.env.MONGODB_CONNECTION_URL;
 const SERVICE_URL = process.env.SERVICE_URL;
+const DEV_PORT = parseInt(process.env.DEV_PORT);
 
 export {
 	CLIENT_TOKEN_SECRET,
 	MONGODB_CONNECTION_URL,
 	SERVICE_URL,
+	DEV_PORT
 };

--- a/src/config.js
+++ b/src/config.js
@@ -2,8 +2,10 @@ import 'dotenv/config';
 
 const CLIENT_TOKEN_SECRET = process.env.CLIENT_TOKEN_SECRET;
 const MONGODB_CONNECTION_URL = process.env.MONGODB_CONNECTION_URL;
+const SERVICE_URL = process.env.SERVICE_URL;
 
 export {
 	CLIENT_TOKEN_SECRET,
 	MONGODB_CONNECTION_URL,
+	SERVICE_URL,
 };

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -1,99 +1,120 @@
 import jwt from 'jsonwebtoken';
-import request from 'request';
-import { parseString } from 'xml2js';
+import bent from 'bent';
+import { parseStringPromise } from 'xml2js';
 import { processors } from 'xml2js';
 
 import { User } from '../models';
-import { CLIENT_TOKEN_SECRET } from '../config';
+import { CLIENT_TOKEN_SECRET, SERVICE_URL } from '../config';
 
-/* Routing for the homepage. Front end sends a get request to the backend and here is the 
- * handling for that get request.
- */
+const get = bent('GET', 'string');
 
-function oAuth(req, res) {
-	const ticket = req.query.ticket;
-	const d = new Date();
+async function oAuth(request, response) {
+    const ticket = request.query.ticket;
 
-	if (ticket) {
-		const casValidateURL = 'https://idp.rice.edu/idp/profile/cas/serviceValidate';
-		// This should be the URL that we redirect the user back to after successful CAS authentication
-		const serviceURL = 'http://localhost:3000/login'; // Using local host for testing purposes
+    if (ticket) {
+        const casValidateURL = 'https://idp.rice.edu/idp/profile/cas/serviceValidate';
+        const url = `${casValidateURL}?ticket=${ticket}&service=${SERVICE_URL}`;
 
-		const url = `${casValidateURL}?ticket=${ticket}&service=${serviceURL}`;
+        const rawXML = await get(url)
+            .catch(() => {
+                return response
+                    .status(500)
+                    .send();
+            });
 
-		request(url, function (err, _, body) {
+        const result = await parseStringPromise(rawXML, { tagNameProcessors: [processors.stripPrefix], explicitArray: false })
+            .then((value) => {
+                if (value.authenticationSuccess) {
+                    value.serviceResponse.authenticationSuccess.user = value.serviceResponse.authenticationSuccess.user.toLowerCase();
+                }
 
-			if (err) return res.status(500);
+                return value;
+            })
+            .catch(() => {
+                return response
+                    .status(500)
+                    .send();
+            });
 
-			/* Parsing the XML body returned from CAS authentication */
-			parseString(body, { tagNameProcessors: [processors.stripPrefix], explicitArray: false }, function (err, result) {
+        if (result.serviceResponse.authenticationSuccess) {
+            const currentUser = await User.findOne({
+                netID: result.serviceResponse.authenticationSuccess.user
+            });
 
-				if (err) {
-					return res.status(500);
-				}
+            const isNewUser = currentUser == null;
 
-				const serviceResponse = result.serviceResponse;
-				const authSuccess = serviceResponse.authenticationSuccess;
+            var userID = null;
+            var netID = null;
+            var token = null;
 
-				if (authSuccess) {
-					const token = jwt.sign({ data: authSuccess }, CLIENT_TOKEN_SECRET);
-					var newUserCheck = null;
+            if (isNewUser) {
+                const newToken = jwt.sign({
+                    data: result.serviceResponse.authenticationSuccess,
+                }, CLIENT_TOKEN_SECRET, {
+                    expiresIn: 60 * 60 * 24 * 7,
+                });
 
-					// Make netID lowercase to help avoid duplicate accounts
-					authSuccess.user = authSuccess.user.toLowerCase();
+                const newUser = await User
+                    .create({
+                        netID: result.serviceResponse.authenticationSuccess.user,
+                        username: result.serviceResponse.authenticationSuccess.user,
+                        token: newToken,
+                    }).catch(() => {
+                        return res
+                            .status(500)
+                            .send();
+                    });
+                userID = newUser._id;
+                netID = newUser.netID;
+                token = newToken;
+            } else {
+                try {
+                    jwt.verify(currentUser.token, CLIENT_TOKEN_SECRET);
+                } catch {
+                    currentUser.token = jwt.sign({
+                        data: result.serviceResponse.authenticationSuccess,
+                    }, CLIENT_TOKEN_SECRET, {
+                        expiresIn: 60 * 60 * 24 * 7,
+                    });
 
-					// Try to find the user in our database
-					User.findOne({ username: authSuccess.user }, function (err, user) {
-						if (err) {
-							return res.status(500).send('Internal Error');
-						}
-						var userID = null;
-						var netID = null;
+                    await currentUser.save();
+                }
 
-						if (!user) {
-							// Create a new user
-							User.create({
-								netID: authSuccess.user,
-								username: authSuccess.user,
-								token: token,
-							}, function (err, newUser) {
-								if (err) {
-									return res.status(500).send();
-								}
+                userID = currentUser._id;
+                netID = currentUser.netID;
+                token = currentUser.token;
+            }
 
-								newUserCheck = true;
-								userID = newUser._id;
-							});
+            return response
+                .status(200)
+                .json({
+                    success: true,
+                    message: "CAS authentication succeeeded!",
+                    isNewUser: isNewUser,
+                    user: {
+                        _id: userID,
+                        netID: netID,
+                        token: token,
+                    }
+                });
 
-						} else {
-							// Existing user -- just need to send token to front end
-							newUserCheck = false;
-							userID = user._id;
-							netID = user.username;
-						}
-
-						res.json({
-							success: true,
-							message: 'CAS authentication successful',
-							isNewUser: newUserCheck,
-							user: {
-								_id: userID,
-								netID: netID,
-								token: token,
-							},
-						});
-						return res.status(200);
-					});
-				} else if (serviceResponse.authenticationFailure) {
-					return res.status(401).json({ success: false, message: 'CAS authentication failed' });
-				} else {
-					return res.status(500).send();
-				}
-			})
-		})
-	} else {
-		return res.status(400);
-	}
+        } else if (result.authenticationFailure) {
+            return response
+                .status(401)
+                .json({
+                    success: false,
+                    message: "CAS authentication failed!",
+                });
+        } else {
+            return response
+                .status(500)
+                .send();
+        }
+    } else {
+        return response
+            .status(400)
+            .send();
+    }
 }
 
 export default oAuth;

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -60,7 +60,7 @@ async function oAuth(request, response) {
                         username: result.serviceResponse.authenticationSuccess.user,
                         token: newToken,
                     }).catch(() => {
-                        return res
+                        return response
                             .status(500)
                             .send();
                     });

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,6 @@ const httpServer = http.createServer(app);
 server.installSubscriptionHandlers(httpServer);
 
 httpServer.listen({ port: DEV_PORT }, () => {
-    console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}!`);
-    console.log(`🚀 Subscriptions ready at ws://localhost:${PORT}${server.subscriptionsPath}!`);
+    console.log(`🚀 Server ready at http://localhost:${DEV_PORT}${server.graphqlPath}!`);
+    console.log(`🚀 Subscriptions ready at ws://localhost:${DEV_PORT}${server.subscriptionsPath}!`);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ import {
 const server = new ApolloServer({
     schema: Schema,
     context: (req, res) => {
+        /*
+            TODO: check where the token is actually sent
+        */
         const token = req.token | req.headers.authorization;
         var decoded = null;
 
@@ -24,13 +27,27 @@ const server = new ApolloServer({
         } catch {
             return res.status(403);
         }
-    
+
         return {
             netID: decoded.data.user,
         };
     },
     subscriptions: {
         onConnect: (connectionParams, webSocket, context) => {
+            var decoded = null;
+            /*
+                TODO: chekc where the WebSocket token is actually sent
+            */
+            try {
+                decoded = jwt.verify(connectionParams.authToken, CLIENT_TOKEN_SECRET)
+            } catch {
+                console.log("Invalid token");
+            }
+
+            if (decoded.data.user == context.netID) {
+                console.log("WebSocket request matches logged in user!");
+            }
+
             console.log("WebSocket connected!");
         },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,34 @@
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import http from 'http';
+import jwt from 'jsonwebtoken';
 
 import Schema from './schema';
 import oAuth from './controllers/auth-controller';
 
 import './db';
 
-import { DEV_PORT } from './config';
+import {
+    CLIENT_TOKEN_SECRET,
+    DEV_PORT
+} from './config';
 
 const server = new ApolloServer({
     schema: Schema,
+    context: (req, res) => {
+        const token = req.token | req.headers.authorization;
+        var decoded = null;
+
+        try {
+            decoded = jwt.verify(token, CLIENT_TOKEN_SECRET);
+        } catch {
+            return res.status(403);
+        }
+    
+        return {
+            netID: decoded.data.user,
+        };
+    },
     subscriptions: {
         onConnect: (connectionParams, webSocket, context) => {
             console.log("WebSocket connected!");
@@ -20,9 +38,6 @@ const server = new ApolloServer({
             console.log("WebSocket disconnected!");
         },
     },
-    context: {
-        
-    }
 });
 
 const app = express();

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import http from 'http';
 import jwt from 'jsonwebtoken';
+import cors from 'cors';
 
 import Schema from './schema';
 import oAuth from './controllers/auth-controller';
@@ -15,11 +16,11 @@ import {
 
 const server = new ApolloServer({
     schema: Schema,
-    context: (req, res) => {
+    context: ({ req, res }) => {
         /*
             TODO: check where the token is actually sent
         */
-        const token = req.token | req.headers.authorization;
+        const token = req.token;
         var decoded = null;
 
         try {
@@ -60,7 +61,10 @@ const server = new ApolloServer({
 const app = express();
 
 server.applyMiddleware({ app });
-app.use('/login', oAuth);
+
+app.use('/login', cors({
+    origin: "https://idp.rice.edu/",
+}), oAuth);
 
 const httpServer = http.createServer(app);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import http from 'http';
+
 import Schema from './schema';
 import oAuth from './controllers/auth-controller';
+
 import './db';
 
-const PORT = 3000;
+import { DEV_PORT } from './config';
 
 const server = new ApolloServer({
     schema: Schema,
@@ -32,7 +34,7 @@ const httpServer = http.createServer(app);
 
 server.installSubscriptionHandlers(httpServer);
 
-httpServer.listen({ port: PORT }, () => {
+httpServer.listen({ port: DEV_PORT }, () => {
     console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}!`);
     console.log(`🚀 Subscriptions ready at ws://localhost:${PORT}${server.subscriptionsPath}!`);
 });


### PR DESCRIPTION
The `request` library has been [deprecated since February 11, 2020](https://github.com/request/request/issues/3142). Therefore, the usage of request in `auth-controller.js` is a potentially point of breakage. I rewrote it using [bent](https://www.npmjs.com/package/bent). As part of the rewrite, I replaced callbacks with asynchronous Promises for forwards compatibility.

I started decoding tokens in the context object of `ApolloServer` as well as in the WebSocket connection handlers. Furthermore, I started using CORS to ensure that only Rice IDP can redirect to `/login` with a ticket. 